### PR TITLE
Fix AdSense script URL

### DIFF
--- a/layouts/partials/head/head.html
+++ b/layouts/partials/head/head.html
@@ -10,7 +10,7 @@
 <title>{{ $title }}</title>
 
 <!-- ✅ 插入 AdSense 代码 -->
-<script async src="https.pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-1889557792898634"
+<script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-1889557792898634"
      crossorigin="anonymous"></script>
 
 <link rel='canonical' href='{{ .Permalink }}'>


### PR DESCRIPTION
## Summary
- correct the AdSense script URL to include the https protocol so the script loads properly

## Testing
- not run

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6915503a3c6c8321ab04501d7480da7e)