### PR TITLE
Add privacy policy page (bilingual CN/EN)

### DIFF
--- a/content/page/privacy/index.md
+++ b/content/page/privacy/index.md
@@ -1,0 +1,149 @@
+---
+title: "隐私政策"
+description: "发个小财（我们）的隐私政策与数据使用说明"
+slug: "privacy"
+comments: false
+---
+
+**发个小财（“我们”）**非常重视您的隐私与数据安全。本隐私政策旨在向您说明我们如何收集、使用、存储及保护您的个人信息。请在使用本应用前仔细阅读。
+
+## 1. 我们收集的信息
+
+我们可能会收集以下信息以提供服务和优化体验：
+
+### 1.1 设备与使用数据（自动收集）
+
+- 设备型号、操作系统版本、语言设置
+- 应用交互行为、访问页面、点击记录
+- 崩溃日志、性能数据（用于稳定性优化）
+
+### 1.2 您主动提供的信息
+
+- 邀请码复制行为（不涉及身份识别）
+- 记账、测评输入内容（仅本地或加密存储，不用于识别用户身份）
+- 反馈内容、截图（当您联系支持时）
+
+### 1.3 我们不收集
+
+- 银行账号、券商账号、交易密码、私钥、助记词
+- 精准定位信息（GPS/地址）
+- 生物识别数据（指纹/面部 ID）
+- 任何用于直接识别您身份的信息
+
+## 2. 信息的使用方式
+
+我们使用数据用于：
+
+- 提供优惠信息展示与邀请码复制功能
+- 生成统计分析（例如：消费心理类型、记账报告）
+- 改进 UI/性能/稳定性
+- 响应您的客服支持请求
+- 防止滥用行为（如批量恶意请求、刷邀请码）
+
+## 3. 数据存储与保护
+
+- 我们优先使用**本地存储或加密数据库**保存您输入的数据
+- 服务器数据（如优惠内容）使用 Cloudflare Workers/KV 进行缓存，但**不关联具体用户身份**
+- 传输采用 HTTPS 加密
+- 我们不会出售、出租或共享您的数据给第三方用于营销或身份识别
+
+## 4. 第三方服务说明
+
+我们可能会使用以下第三方服务，但仅用于必要功能：
+
+- Google Play Console（用于 App 发布管理）
+- Firebase/Gradle/Flutter Build 工具链（用于构建和崩溃分析）
+
+这些服务可能会收集匿名或必要的技术数据，但不用于识别您的身份。
+
+## 5. 未成年人隐私保护
+
+本应用**不以 13 岁以下儿童为目标用户**。
+若我们发现误收集到儿童信息，将在确认后立即删除。
+
+## 6. 用户权利
+
+您有权：
+
+- 清除本地存储的记账/测评数据
+- 通过客服联系要求删除服务器缓存中的关联记录（如您上传截图/反馈）
+
+## 7. 政策更新
+
+本隐私政策可能会随版本更新调整。
+更新后我们会在应用内公告，不再另行收集新类型数据。
+
+## 8. 联系我们
+
+如有隐私相关问题，可通过应用内反馈或邮件联系我们。
+
+---
+
+**感谢您的信任与支持！**
+
+本应用始终坚持：
+
+> **不收集身份，不触碰资产数据，只聚合优惠与认知。**
+
+**laosji**  
+2026.01.02
+
+---
+
+**FaGe XiaoCai (“we”, “our”, or “the app”)** respects your privacy. This policy explains what data we collect, how it is used, and how it is protected.
+
+## 1. Data We May Collect
+
+### 1.1 Anonymous Device & Usage Data
+
+- Device model, OS version, language settings
+- Interaction analytics, page visits, click behaviors
+- Crash logs and performance diagnostics
+
+### 1.2 User-Entered Content (Stored Securely)
+
+- Local notes, assessment inputs, saving challenges, bookkeeping entries
+- Support tickets or screenshots you voluntarily submit
+
+## 2. How We Use Data
+
+- Display global fintech coupons and referral codes
+- Generate non-identifiable analytics (e.g., spending psychology insights, monthly reports)
+- Improve UI, performance, and stability
+- Prevent abuse or malicious automation
+
+## 3. What We Do **Not** Collect
+
+- Bank account numbers, brokerage credentials, passwords
+- Private keys, seed phrases, or crypto wallet recovery data
+- Precise GPS or physical addresses
+- Biometric identifiers
+
+## 4. Data Security & Storage
+
+- Local data is stored with encryption or device-level storage
+- Cloudflare Workers/KV may cache offer content, but it is not tied to user identity
+- Data transmission uses HTTPS
+- We do not sell or share data for identity tracking or marketing
+
+## 5. Children’s Privacy
+
+This app is **not targeted at children under 13**. If such data is found, we delete it immediately.
+
+## 6. Your Rights
+
+- Clear local bookkeeping or assessment data anytime
+- Request deletion of support materials you voluntarily sent
+
+## 7. Policy Updates
+
+We may update this policy with new releases and will announce inside the app.
+
+---
+
+**Commitment:**  
+> No identity data. No asset-level sensitive data. Only offers and insights.
+
+**Signed,**  
+laosji.net  
+Jan 2, 2026


### PR DESCRIPTION
### Motivation

- Provide an on-site privacy policy to inform users about data collection, storage, and protection practices for the app.
- Include both Chinese and English versions to support bilingual visitors.

### Description

- Add a new content page at `content/page/privacy/index.md` containing a full privacy policy in Chinese and English with front-matter (`title`, `description`, `slug`, `comments`).
- The policy covers data collection types, usage, storage and protection, third-party services, children’s privacy, user rights, and update/contact instructions.

### Testing

- No site build or automated content validation was run because this is a content-only change.
- Attempted to run `hugo version` to verify local build tooling, but the command failed with `command not found` in the environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69572bbe0bbc8321b3ca1861d967cf32)